### PR TITLE
BulkUpsert request size limit and `.others` column for extra data as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-* Add the logic to automatically limit the request sizes for BulkUpsert, to avoid the ingestion errors
-* Save extra input fields as the (optional) additional JSON-formatted field named `.other`
-* Support for flexible schema parsers like `logfmt` on input
-* Avoid the loss of same-time messages by (optionally) adding extra `.hash` field containing the Cityhash64 computed over the record
+* Added the logic to automatically limit the request sizes for `BulkUpsert`, to avoid the ingestion errors
+* Added the saving extra input fields as the (optional) additional JSON-formatted field named `.other`
+* Supported the flexible schema parsers like `logfmt` on input
+* Fixed the lost of same-time messages by (optionally) adding extra `.hash` field containing the `Cityhash64` computed over the record
 
 ## v1.1.1
 * Fixed Dockerfile for build with go1.22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 
+* Add the logic to automatically limit the request sizes for BulkUpsert, to avoid the ingestion errors
+* Save extra input fields as the (optional) additional JSON-formatted field named `.other`
+* Support for flexible schema parsers like `logfmt` on input
+* Avoid the loss of same-time messages by (optionally) adding extra `.hash` field containing the Cityhash64 computed over the record
+
 ## v1.1.1
 * Fixed Dockerfile for build with go1.22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-## 
 * Add the logic to automatically limit the request sizes for BulkUpsert, to avoid the ingestion errors
 * Save extra input fields as the (optional) additional JSON-formatted field named `.other`
 * Support for flexible schema parsers like `logfmt` on input

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@
 ## Build
 
 ```makefile
-export BIN=out_ydb.so
-make build
+BIN=out_ydb.so make build
 ```
 
 # Usage 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/surge/cityhash v0.0.0-20131128155616-cdd6a94144ab // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/yandex-cloud/go-genproto v0.0.0-20240425114406-68c9b49389a1 // indirect
 	github.com/ydb-platform/ydb-go-genproto v0.0.0-20240316140903-4a47abca1cca // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/fluent/fluent-bit-go v0.0.0-20230731091245-a7a013e2473c
 	github.com/stretchr/testify v1.8.3
-	github.com/ydb-platform/ydb-go-sdk/v3 v3.66.0
+	github.com/ydb-platform/ydb-go-sdk/v3 v3.66.1
 	github.com/ydb-platform/ydb-go-yc v0.12.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -790,6 +790,8 @@ github.com/ydb-platform/ydb-go-sdk/v3 v3.44.0/go.mod h1:oSLwnuilwIpaF5bJJMAofnGg
 github.com/ydb-platform/ydb-go-sdk/v3 v3.47.3/go.mod h1:bWnOIcUHd7+Sl7DN+yhyY1H/I61z53GczvwJgXMgvj0=
 github.com/ydb-platform/ydb-go-sdk/v3 v3.66.0 h1:ffZ1Kh60rA62BVHVafH/xrIn5yrlJ/ZDvIoVg7mhVGo=
 github.com/ydb-platform/ydb-go-sdk/v3 v3.66.0/go.mod h1:hGX4CijskNnUTRgLlqMvZdrBQc1ALZgAnKHytF5nmj4=
+github.com/ydb-platform/ydb-go-sdk/v3 v3.66.1 h1:K6TNapbuMFTFFMil26rP3fMgZmuLE9jP8curXRyKlZs=
+github.com/ydb-platform/ydb-go-sdk/v3 v3.66.1/go.mod h1:hGX4CijskNnUTRgLlqMvZdrBQc1ALZgAnKHytF5nmj4=
 github.com/ydb-platform/ydb-go-yc v0.12.1 h1:qw3Fa+T81+Kpu5Io2vYHJOwcrYrVjgJlT6t/0dOXJrA=
 github.com/ydb-platform/ydb-go-yc v0.12.1/go.mod h1:t/ZA4ECdgPWjAb4jyDe8AzQZB5dhpGbi3iCahFaNwBY=
 github.com/ydb-platform/ydb-go-yc-metadata v0.6.1 h1:9E5q8Nsy2RiJMZDNVy0A3KUrIMBPakJ2VgloeWbcI84=

--- a/go.sum
+++ b/go.sum
@@ -773,6 +773,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/surge/cityhash v0.0.0-20131128155616-cdd6a94144ab h1:Kmv2LOAf1bYObq0HW/XuLP4U92z3aXVHhAgdvE2u7BQ=
+github.com/surge/cityhash v0.0.0-20131128155616-cdd6a94144ab/go.mod h1:o8cYsNqWX8QahvKFMeXIFD1R5+df885pkwh8Vo/htck=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ const (
 	KeyTimestamp = ".timestamp"
 	KeyInput     = ".input"
 	KeyOthers    = ".others"
+	KeyHash      = ".hash"
 )
 
 type credentialsDescription struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ const (
 
 	KeyTimestamp = ".timestamp"
 	KeyInput     = ".input"
+	KeyOthers    = ".others"
 )
 
 type credentialsDescription struct {

--- a/internal/storage/ydb.go
+++ b/internal/storage/ydb.go
@@ -77,6 +77,7 @@ const (
 	jsonType         = "Json"
 	jsonDocumentType = "JsonDocument"
 	timestampType    = "Timestamp"
+	uint64Type       = "Uint64"
 )
 
 func (s *YDB) resolveFieldMapping(ctx context.Context) error {
@@ -191,6 +192,13 @@ func type2Type(t types.Type, v interface{}) (types.Value, int, error) {
 			return convertTimestamp(optional, v), Sz64, nil
 		default:
 			return nil, -1, fmt.Errorf("not supported conversion (string) from '%s' to '%s' (%s)", v, columnTypeYql, t)
+		}
+	case uint64:
+		switch columnTypeYql {
+		case uint64Type:
+			return convertValueIfOptional(optional, types.Uint64Value(v)), Sz8 + Sz8, nil
+		default:
+			return nil, -1, fmt.Errorf("not supported conversion (uint64) from '%v' to '%s' (%s)", v, columnTypeYql, t)
 		}
 	case map[interface{}]interface{}:
 		j, err := json.Marshal(convertByteFieldsToString(v))

--- a/internal/storage/ydb_test.go
+++ b/internal/storage/ydb_test.go
@@ -116,7 +116,7 @@ func TestType2TypeOk(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := type2Type(tc.column, tc.value)
+			actual, _, err := type2Type(tc.column, tc.value)
 
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, actual)


### PR DESCRIPTION
1. Some inputs (one example is `systemd-journald`) can push lots of data in a single batch, which has to be properly handled on the output side. For YDB output this means splitting the `BulkUpsert` request into multiple peaces, otherwise it may fail with `Invalid request` message.
2. Some parsers (noteably `logfmt`) provide variadic output, having very different keys on each row.  YDB's `BulkUpsert` call, by convention, must get the list of structures having the same column names and data types in each row. The plugin implementation has been updated to always include the "missing" columns with NULL or default value.
3. It seems to be handly to catch the extra column's input into JSON to allow access to columns that were not explicitly defined, and are probably blank or missing in most of the records. Added `.others` input pseudo-column to catch all unmatched columns to a single JSON value.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #12 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
